### PR TITLE
fix for other country eg. China, www.bing.com will redirect to cn.bing.c...

### DIFF
--- a/bing-wallpaper.sh
+++ b/bing-wallpaper.sh
@@ -4,7 +4,7 @@ PICTURE_DIR="$HOME/Pictures/bing-wallpapers/"
 
 mkdir -p $PICTURE_DIR
 
-urls=( $(curl -s http://www.bing.com | \
+urls=( $(curl -s http://www.bing.com -b '_FS=NU=1&mkt=en-us&ui=#en-us' | \
     grep -Eo "url:'.*?'" | \
     sed -e "s/url:'\([^']*\)'.*/http:\/\/bing.com\1/" | \
     sed -e "s/\\\//g") )


### PR DESCRIPTION
add this cookie, so that other country's www.bing.com will not redirect.
