### PR TITLE
use osx db directly to update desktop pictures with -w

### DIFF
--- a/bing-wallpaper.sh
+++ b/bing-wallpaper.sh
@@ -115,7 +115,5 @@ for p in "${urls[@]}"; do
 done
 
 if [ $SET_WALLPAPER ]; then
-    /usr/bin/osascript<<END
-tell application "System Events" to set picture of every desktop to ("$PICTURE_DIR/$filename" as POSIX file as alias)
-END
+	/usr/bin/sqlite3 $HOME/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '$PICTURE_DIR/$filename'" && killall Dock
 fi


### PR DESCRIPTION
Causes updates to happen to *all* desktops, including those
with multiple spaces that are not visible.